### PR TITLE
ENTREP-88 Remove non-sanctioned behaviors: Part II

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -301,7 +301,8 @@ export const actionToggleTheme = register({
       commitToHistory: false,
     };
   },
-  keyTest: (event) => event.altKey && event.shiftKey && event.code === CODES.D,
+  keyTest: () => false,
+  // keyTest: (event) => event.altKey && event.shiftKey && event.code === CODES.D,
   predicate: (elements, appState, props, app) => {
     return !!app.props.UIOptions.canvasActions.toggleTheme;
   },

--- a/src/actions/actionClipboard.tsx
+++ b/src/actions/actionClipboard.tsx
@@ -60,7 +60,8 @@ export const actionCut = register({
     return app.device.isMobile && !!navigator.clipboard;
   },
   contextItemLabel: "labels.cut",
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.X,
+  keyTest: () => false,
+  // keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.X,
 });
 
 export const actionCopyAsSvg = register({

--- a/src/actions/actionElementLock.ts
+++ b/src/actions/actionElementLock.ts
@@ -49,14 +49,15 @@ export const actionToggleElementLock = register({
       ? "labels.elementLock.lockAll"
       : "labels.elementLock.unlockAll";
   },
-  keyTest: (event, appState, elements) => {
-    return (
-      event.key.toLocaleLowerCase() === KEYS.L &&
-      event[KEYS.CTRL_OR_CMD] &&
-      event.shiftKey &&
-      getSelectedElements(elements, appState, false).length > 0
-    );
-  },
+  keyTest: () => false,
+  // keyTest: (event, appState, elements) => {
+  //   return (
+  //     event.key.toLocaleLowerCase() === KEYS.L &&
+  //     event[KEYS.CTRL_OR_CMD] &&
+  //     event.shiftKey &&
+  //     getSelectedElements(elements, appState, false).length > 0
+  //   );
+  // },
 });
 
 export const actionUnlockAllElements = register({

--- a/src/actions/actionMenu.tsx
+++ b/src/actions/actionMenu.tsx
@@ -86,5 +86,6 @@ export const actionShortcuts = register({
       commitToHistory: false,
     };
   },
-  keyTest: (event) => event.key === KEYS.QUESTION_MARK,
+  keyTest: () => false,
+  // keyTest: (event) => event.key === KEYS.QUESTION_MARK,
 });

--- a/src/actions/actionToggleStats.tsx
+++ b/src/actions/actionToggleStats.tsx
@@ -16,6 +16,7 @@ export const actionToggleStats = register({
   },
   checked: (appState) => appState.showStats,
   contextItemLabel: "stats.title",
-  keyTest: (event) =>
-    !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.SLASH,
+  keyTest: () => false,
+  // keyTest: (event) =>
+  //   !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.SLASH,
 });

--- a/src/actions/actionToggleViewMode.tsx
+++ b/src/actions/actionToggleViewMode.tsx
@@ -22,6 +22,6 @@ export const actionToggleViewMode = register({
     return typeof appProps.viewModeEnabled === "undefined";
   },
   contextItemLabel: "labels.viewMode",
-  keyTest: (event) =>
-    !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.R,
+  keyTest: () => false,
+  // !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.R,
 });

--- a/src/actions/actionToggleZenMode.tsx
+++ b/src/actions/actionToggleZenMode.tsx
@@ -22,6 +22,7 @@ export const actionToggleZenMode = register({
     return typeof appProps.zenModeEnabled === "undefined";
   },
   contextItemLabel: "buttons.zenMode",
-  keyTest: (event) =>
-    !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.Z,
+  keyTest: () => false,
+  // keyTest: (event) =>
+  //   !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.Z,
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2892,34 +2892,34 @@ class App extends React.Component<AppProps, AppState> {
 
     resetCursor(this.canvas);
     if (!event[KEYS.CTRL_OR_CMD] && !this.state.viewModeEnabled) {
-      const container = getTextBindableContainerAtPosition(
-        this.scene.getNonDeletedElements(),
-        this.state,
-        sceneX,
-        sceneY,
-      );
-      if (container) {
-        if (
-          hasBoundTextElement(container) ||
-          !isTransparent(container.backgroundColor) ||
-          isHittingElementNotConsideringBoundingBox(container, this.state, [
-            sceneX,
-            sceneY,
-          ])
-        ) {
-          const midPoint = getContainerCenter(container, this.state);
+      // const container = getTextBindableContainerAtPosition(
+      //   this.scene.getNonDeletedElements(),
+      //   this.state,
+      //   sceneX,
+      //   sceneY,
+      // );
+      // if (container) {
+      //   if (
+      //     hasBoundTextElement(container) ||
+      //     !isTransparent(container.backgroundColor) ||
+      //     isHittingElementNotConsideringBoundingBox(container, this.state, [
+      //       sceneX,
+      //       sceneY,
+      //     ])
+      //   ) {
+      //     const midPoint = getContainerCenter(container, this.state);
 
-          sceneX = midPoint.x;
-          sceneY = midPoint.y;
-        }
-      }
+      //     sceneX = midPoint.x;
+      //     sceneY = midPoint.y;
+      //   }
+      // }
       const hitElement = this.getElementAtPosition(sceneX, sceneY);
       if (isTextElement(hitElement)) {
         this.startTextEditing({
           sceneX,
           sceneY,
           insertAtParentCenter: !event.altKey,
-          container,
+          container: null,
         });
       }
     }
@@ -4794,68 +4794,68 @@ class App extends React.Component<AppProps, AppState> {
           );
           this.maybeSuggestBindingForAll(selectedElements);
 
-          // We duplicate the selected element if alt is pressed on pointer move
-          if (event.altKey && !pointerDownState.hit.hasBeenDuplicated) {
-            // Move the currently selected elements to the top of the z index stack, and
-            // put the duplicates where the selected elements used to be.
-            // (the origin point where the dragging started)
+          // // We duplicate the selected element if alt is pressed on pointer move
+          // if (event.altKey && !pointerDownState.hit.hasBeenDuplicated) {
+          //   // Move the currently selected elements to the top of the z index stack, and
+          //   // put the duplicates where the selected elements used to be.
+          //   // (the origin point where the dragging started)
 
-            pointerDownState.hit.hasBeenDuplicated = true;
+          //   pointerDownState.hit.hasBeenDuplicated = true;
 
-            const nextElements = [];
-            const elementsToAppend = [];
-            const groupIdMap = new Map();
-            const oldIdToDuplicatedId = new Map();
-            const hitElement = pointerDownState.hit.element;
-            const elements = this.scene.getElementsIncludingDeleted();
-            const selectedElementIds: Array<ExcalidrawElement["id"]> =
-              getSelectedElements(elements, this.state, true).map(
-                (element) => element.id,
-              );
+          //   const nextElements = [];
+          //   const elementsToAppend = [];
+          //   const groupIdMap = new Map();
+          //   const oldIdToDuplicatedId = new Map();
+          //   const hitElement = pointerDownState.hit.element;
+          //   const elements = this.scene.getElementsIncludingDeleted();
+          //   const selectedElementIds: Array<ExcalidrawElement["id"]> =
+          //     getSelectedElements(elements, this.state, true).map(
+          //       (element) => element.id,
+          //     );
 
-            for (const element of elements) {
-              if (
-                selectedElementIds.includes(element.id) ||
-                // case: the state.selectedElementIds might not have been
-                // updated yet by the time this mousemove event is fired
-                (element.id === hitElement?.id &&
-                  pointerDownState.hit.wasAddedToSelection)
-              ) {
-                const duplicatedElement = duplicateElement(
-                  this.state.editingGroupId,
-                  groupIdMap,
-                  element,
-                );
-                const [originDragX, originDragY] = getGridPoint(
-                  pointerDownState.origin.x - pointerDownState.drag.offset.x,
-                  pointerDownState.origin.y - pointerDownState.drag.offset.y,
-                  this.state.gridSize,
-                );
-                mutateElement(duplicatedElement, {
-                  x: duplicatedElement.x + (originDragX - dragX),
-                  y: duplicatedElement.y + (originDragY - dragY),
-                });
-                nextElements.push(duplicatedElement);
-                elementsToAppend.push(element);
-                oldIdToDuplicatedId.set(element.id, duplicatedElement.id);
-              } else {
-                nextElements.push(element);
-              }
-            }
-            const nextSceneElements = [...nextElements, ...elementsToAppend];
-            bindTextToShapeAfterDuplication(
-              nextElements,
-              elementsToAppend,
-              oldIdToDuplicatedId,
-            );
-            fixBindingsAfterDuplication(
-              nextSceneElements,
-              elementsToAppend,
-              oldIdToDuplicatedId,
-              "duplicatesServeAsOld",
-            );
-            this.scene.replaceAllElements(nextSceneElements);
-          }
+          //   for (const element of elements) {
+          //     if (
+          //       selectedElementIds.includes(element.id) ||
+          //       // case: the state.selectedElementIds might not have been
+          //       // updated yet by the time this mousemove event is fired
+          //       (element.id === hitElement?.id &&
+          //         pointerDownState.hit.wasAddedToSelection)
+          //     ) {
+          //       const duplicatedElement = duplicateElement(
+          //         this.state.editingGroupId,
+          //         groupIdMap,
+          //         element,
+          //       );
+          //       const [originDragX, originDragY] = getGridPoint(
+          //         pointerDownState.origin.x - pointerDownState.drag.offset.x,
+          //         pointerDownState.origin.y - pointerDownState.drag.offset.y,
+          //         this.state.gridSize,
+          //       );
+          //       mutateElement(duplicatedElement, {
+          //         x: duplicatedElement.x + (originDragX - dragX),
+          //         y: duplicatedElement.y + (originDragY - dragY),
+          //       });
+          //       nextElements.push(duplicatedElement);
+          //       elementsToAppend.push(element);
+          //       oldIdToDuplicatedId.set(element.id, duplicatedElement.id);
+          //     } else {
+          //       nextElements.push(element);
+          //     }
+          //   }
+          //   const nextSceneElements = [...nextElements, ...elementsToAppend];
+          //   bindTextToShapeAfterDuplication(
+          //     nextElements,
+          //     elementsToAppend,
+          //     oldIdToDuplicatedId,
+          //   );
+          //   fixBindingsAfterDuplication(
+          //     nextSceneElements,
+          //     elementsToAppend,
+          //     oldIdToDuplicatedId,
+          //     "duplicatesServeAsOld",
+          //   );
+          //   this.scene.replaceAllElements(nextSceneElements);
+          // }
           return;
         }
       }
@@ -6330,7 +6330,6 @@ class App extends React.Component<AppProps, AppState> {
       actionGroup,
       actionUnbindText,
       actionBindText,
-      actionWrapTextInContainer,
       actionUngroup,
       CONTEXT_MENU_SEPARATOR,
       //   actionAddToLibrary,

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -47,10 +47,6 @@ const getHints = ({
     return t("hints.freeDraw");
   }
 
-  if (activeTool.type === "text") {
-    return t("hints.text");
-  }
-
   if (appState.activeTool.type === "image" && appState.pendingImageElementId) {
     return t("hints.placeImage");
   }

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -105,9 +105,6 @@ const getHints = ({
       }
       return t("hints.lineEditor_info");
     }
-    if (isTextBindableContainer(selectedElements[0])) {
-      return t("hints.bindTextToElement");
-    }
   }
 
   return null;

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -56,10 +56,6 @@ const Footer = ({
         </Stack.Col>
       </div>
       <FooterCenterTunnel.Out />
-      <ExitZenModeAction
-        actionManager={actionManager}
-        showExitZenModeBtn={showExitZenModeBtn}
-      />
     </footer>
   );
 };

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -264,7 +264,8 @@ export const actionLink = register({
     };
   },
   trackEvent: { category: "hyperlink", action: "click" },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.K,
+  keyTest: () => false,
+  // keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.K,
   contextItemLabel: (elements, appState) =>
     getContextMenuLabel(elements, appState),
   predicate: (elements, appState) => {


### PR DESCRIPTION
Found a few more shortcuts/behaviors to squash while working on this.  Duplicate via opt-drag/alt-drag was handled in the previous PR.  Most stuff is just commented out rather than deleted in case we want to reintroduce them with tokens somehow.